### PR TITLE
 Fix broken doc for image delete

### DIFF
--- a/google_cloud.md
+++ b/google_cloud.md
@@ -65,10 +65,10 @@ $ ops image list
 
 ### Delete Image
 
-`ops image delete -i <imagename>` can be used to delete an image from Google Cloud.
+`ops image delete <imagename>` can be used to delete an image from Google Cloud.
 
 ```
-$ ops delete image -i nanos-main-image
+$ ops delete image nanos-main-image
 ```
 
 ## Instance Operations


### PR DESCRIPTION
-i switch does not appear in the latest version installed.  You just provide the image name without the switch and it works.
Ops version: 0.1.11
Nanos version: 0.1.26