### PR TITLE
Add aws and azure vpc/subnet/security group documentation 

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -120,6 +120,19 @@ Sample config
 }
 ```
 
+#### VPC and Security Group
+
+By default, ops uses the first VPC found in aws and creates a security group per instance.
+
+You can select a different VPC or use a existing security group using the configuration file. The keys to set are `RunConfig.VPC` and `RunConfig.SecurityGroup`.
+```json
+{
+    "RunConfig":{
+        "VPC": "vpc-name",
+        "SecurityGroup": "sg-name"
+    }
+}
+```
 
 ### List Instances
 
@@ -139,7 +152,7 @@ Alternatively you can pass project-id and zone with cli options.
 $ ops instance list -p prod-1000 -z us-west1-b
 ```
 
-## Get Logs for Instance
+### Get Logs for Instance
 
 You can get logs from serial console of a particular instance using `ops instance logs` command.
 

--- a/azure.md
+++ b/azure.md
@@ -94,6 +94,21 @@ export AZURE_BASE_GROUP_NAME=""
 ops instance create -z westus2 -t azure -i bob
 ```
 
+#### VPC, Subnet and Security Group
+
+By default, ops creates a VPC, a subnet and a security group per instance.
+
+You can select a different VPC, subnet or security group using the configuration file. The keys to set are `RunConfig.VPC`, `RunConfig.Subnet` and `RunConfig.SecurityGroup`.
+```json
+{
+    "RunConfig":{
+        "VPC": "vpc-name",
+        "Subnet": "subnet-name",
+        "SecurityGroup": "sg-name"
+    }
+}
+```
+
 ### List Instances
 
 ```sh
@@ -108,7 +123,7 @@ export AZURE_BASE_GROUP_NAME=""
 ops instance list -t azure -z us-west-2
 ```
 
-## Get Logs for Instance
+### Get Logs for Instance
 
 You can get logs from serial console of a particular instance using `ops instance logs` command.
 The logs are stored in your cloud storage bucket.

--- a/google_cloud.md
+++ b/google_cloud.md
@@ -132,7 +132,7 @@ Alternatively you can pass project-id and zone with cli options.
 $ ops instance list -g prod-1000 -z us-west1-b
 ```
 
-## Get Logs for Instance
+### Get Logs for Instance
 
 You can get logs from serial console of a particular instance using `ops instance logs` command.
 

--- a/hyper-v.md
+++ b/hyper-v.md
@@ -21,6 +21,6 @@ https://nanovms.com/services/subscription
 
 ### List Instances
 
-## Get Logs for Instance
+### Get Logs for Instance
 
 ### Delete Instance

--- a/openstack.md
+++ b/openstack.md
@@ -112,8 +112,8 @@ Sample config file
 ```json
 {
   "CloudConfig" :{
-    "Platform" : "openstack", 
-    "flavor" : "<flavor_name>" 
+    "Platform" : "openstack",
+    "flavor" : "<flavor_name>"
   }
 }
 ```
@@ -141,7 +141,7 @@ export OS_PROJECT_ID=""
 ops instance list -t openstack -z us-west-2
 ```
 
-## Get Logs for Instance
+### Get Logs for Instance
 
 ### Delete Instance
 ```sh

--- a/vsphere.md
+++ b/vsphere.md
@@ -107,7 +107,7 @@ require a new ARP request to be sent. If you already know the ip in
 question you can simply connect to it or you can reboot the vm and that
 will generate traffic.
 
-## Get Logs for Instance
+### Get Logs for Instance
 
 You can obtain the logs via:
 

--- a/vultr.md
+++ b/vultr.md
@@ -78,7 +78,7 @@ VULTR_SECRET=my_vultr_secret \
 ops instance list -z ewr1 -t vultr
 ```
 
-## Get Logs for Instance
+### Get Logs for Instance
 
 ### Delete Instance
 


### PR DESCRIPTION
(closes #137)

* Fixes header style used by section "Get Logs for Instance" in cloud providers documentation.