### PR TITLE
fix Debian / Ubuntu QEMU installation line

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -23,7 +23,7 @@ On Linux flavors ensure that you have QEMU version 2.5 or greater installed.
  To install `QEMU`, run the following command:
 
 ```sh
-$ sudo apt-get install qemu
+$ sudo apt-get install qemu-kvm qemu-utils
 ```
 
 ##### Fedora (dnf/yum) {#qemu-fedora}

--- a/prerequisites.md
+++ b/prerequisites.md
@@ -32,10 +32,10 @@ For alternate ways of installing QEMU, see their
 
 ##### Debian / Ubuntu (apt-get)
 
- 1. To install `QMEU`, run the following command...
+ 1. To install `QEMU`, run the following command...
 
 ```sh
-$ sudo apt-get install qemu
+$ sudo apt-get install qemu-kvm qemu-utils
 ```
 
 ##### Fedora (dnf/yum)


### PR DESCRIPTION
Updated instructions to point to qemu-kvm and qemu-utils (which provides
qemu-img), matching the Fedora instructions.

As of Debian 10 ("buster"), and Ubuntu 20.04LTS ("focal"), qemu became a
dummy package that does not install anything, and the dummy package
description states that users should install individual pieces.

Note the lack of dependencies:
https://packages.debian.org/buster/qemu
https://packages.ubuntu.com/focal/qemu

Whereas previous versions did have dependencies that would bring working
qemu system instance and utilities:
https://packages.debian.org/stretch/qemu
https://packages.ubuntu.com/bionic/qemu

Signed-off-by: Paul Ivanov <pi@berkeley.edu>