### PR TITLE
fix: remove unnecessary comma in imgcreate.json code snippet

### DIFF
--- a/volumes.md
+++ b/volumes.md
@@ -383,7 +383,7 @@ imgcreate.json:
 ```
 {
   "Mounts": {
-    "%1": "/static",
+    "%1": "/static"
   },
   "RunConfig": {
     "Ports": [


### PR DESCRIPTION
Hi everyone,

The current code snippet for `imgcreate.json`  in **volumes.md**  file contains an extra comma which breaks the code. So I have fixed it by removing that unnecessary extra comma.

Also I have attached 2 image files showing the output response for both code snippet.
- Image before commit:
![extra_comma](https://github.com/nanovms/ops-documentation/assets/52379037/d1df9105-e2e2-4941-aa74-030eb84d0289)

- Image after commit
![remove_extra_comma](https://github.com/nanovms/ops-documentation/assets/52379037/f346143e-1436-41da-b787-4240ee190590)
 
PLUS: 
I had discussed about this issue with @eyberg in LinkedIn.

