### PR TITLE
configuration: remove brackets from NanosVersion example

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -593,7 +593,7 @@ See further instructions about volumes in dedicated [documentation](volumes.md) 
 
 ```json
 {
-    "NanosVersion": ["nightly"]
+    "NanosVersion": "nightly"
 }
 ```
 


### PR DESCRIPTION
The `NanosVersion` field should be set to a string (no brackets).