### PR TITLE
Add `-m 256` flag because of error on macos

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -11,7 +11,7 @@ need Node installed for this as ops will automatically download a Node
 package for you:
 
 ```sh
-$ ops pkg load eyberg/node:20.5.0 -p 8083 -f -n -a hi.js
+$ ops pkg load eyberg/node:20.5.0 -p 8083 -f -n -a hi.js -m 256
 ```
 
 Note: We have a list of pre-made Node packages on the


### PR DESCRIPTION
Prevents error `frame 0x00ff800042002000 already full` because of no specified memory. When trying to run the node package on MacOS using the provided command without the memory flag, the previously mentioned error message appears.