### PR TITLE
cloud_init and firewall: Update documentation to include latest kernel features

### DIFF
--- a/klibs.md
+++ b/klibs.md
@@ -1236,6 +1236,24 @@ Example contents of Ops configuration file:
   }
 ```
 
+### Dynamic Firewall Rules
+
+In addition to static firewall rules defined in the configuration manifest, the firewall can retrieve dynamic rules from Radar (this requires a Radar API key).
+When this functionality is enabled, the firewall downloads from the Radar server a list of IP addresses that are known sources of spam or other abusive behavior, and automatically adds a set of rules that block all network traffic originating from those addresses.
+
+Example contents of Ops configuration file to retrieve firewall rules from Radar:
+
+```
+  "ManifestPassthrough": {
+    "firewall": {
+      "dynamic_rules":["radar"]
+    }
+  },
+  "Env": {
+    "RADAR_KEY": "my_radar_api_key"
+  }
+```
+
 ## Sandbox
 
 This klib implements a __sandboxing mechanism__ by which the capabilities of the running process can be _restricted_ by _overriding certain syscall handlers_.

--- a/klibs.md
+++ b/klibs.md
@@ -845,8 +845,6 @@ where `<auth-scheme>` and  `<authorization-parameters>` are configurable.
 Certain caveats to be aware of:
 
 * Only direct download links are supported today. (no redirects)
-* HTTP chunked transfer encoding is not supported, (don't try to download a movie).
-  If the source server uses this encoding, a file download may never complete.
 * When cloud_init cannot download one or more files, the kernel does not start the user program.
   The rationale for this is that we want all files to be ready and accessible when the program starts.
 * When used to populate the user environment, only string-valued attributes are converted to environment variables (**non-string-valued attributes are ignored**).


### PR DESCRIPTION
Since https://github.com/nanovms/nanos/pull/2170, the cloud_init klib supports downloading files with chunked transfer encoding, and the firewall klib supports retrieving a blacklist of IP addresses from Radar.